### PR TITLE
Basic implementation of pore upload.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,5 @@ git2 = "0.8"
 
 console = "0.7"
 indicatif = "0.11"
+
+clt = "0.0.6"

--- a/src/depot.rs
+++ b/src/depot.rs
@@ -210,6 +210,9 @@ impl Depot {
         self.refs_mirror(&remote_config.name, project).to_str().unwrap(),
       )
       .context("failed to create remote")?;
+
+    // TODO: The push URL should be based on the review element of the manifest.
+    // Projects may fetch from one remote but push to another.
     repo
       .remote_set_pushurl(&remote_config.name, Some(&format!("{}{}", remote_config.url, project)))
       .context("failed to set remote pushurl")?;


### PR DESCRIPTION
Supports most of the options `repo upload` does. It's still missing:

* `--br`
* `--draft` (iirc draft changes aren't a thing any more?)
* `--no-emails` (is this something that een should be supported?)
* `--push-option`
* `--destination`
* `--no-cert-checks`
* `--no-verify` (not useful until preupload hooks are supported)

It also doesn't support the interactive branch selection workflow (`--cbr` is required), and currently only supports a single path.