### PR TITLE
Implement fetching/syncing of other branches.

### DIFF
--- a/src/depot.rs
+++ b/src/depot.rs
@@ -122,7 +122,7 @@ impl Depot {
     &self,
     remote_config: &config::RemoteConfig,
     project: &str,
-    branch: &str,
+    targets: Option<&[String]>,
     depth: Option<i32>,
   ) -> Result<(), Error> {
     ensure!(!project.starts_with('/'), "invalid project path {}", project);
@@ -150,12 +150,17 @@ impl Depot {
       .arg(&objects_path)
       .arg("fetch")
       .arg(&remote_config.name)
-      .arg(&branch)
       .arg("--no-tags");
 
     if let Some(depth) = depth {
       cmd.arg("--depth");
       cmd.arg(depth.to_string());
+    }
+
+    if let Some(targets) = targets {
+      for target in targets {
+        cmd.arg(&target);
+      }
     }
 
     let git_output = cmd.output().context("failed to spawn git fetch")?;


### PR DESCRIPTION
This adds `pore fetch/sync [-a] [-b BRANCH]...`, and `pore sync -r` to only update remotes.

This makes me wonder whether `pore fetch` should work without a tree. My original intended use-case was a cronjob to run `pore -C /foo/bar/aosp fetch`, but maybe something like `pore fetch aosp/master` that grabs a manifest and then fetches all of the repos would be better?