### PR TITLE
Implement multi-project upload.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -198,6 +198,7 @@ fn cmd_upload(
   branch_name_as_topic: bool,
   autosubmit: bool,
   presubmit_ready: bool,
+  dry_run: bool,
 ) -> Result<i32, Error> {
   tree.upload(
     config,
@@ -212,6 +213,7 @@ fn cmd_upload(
     branch_name_as_topic,
     autosubmit,
     presubmit_ready,
+    dry_run,
   )
 }
 
@@ -374,6 +376,7 @@ fn main() {
       (@arg NO_AUTOSUBMIT: --("no-autosubmit") +multiple "do not enable autosubmit")
       (@arg PRESUBMIT: --presubmit +multiple "queue the change for presubmit")
       (@arg NO_PRESUBMIT: --("no-presubmit") +multiple "do not queue the change for presubmit")
+      (@arg DRY_RUN: --("dry-run") "don't upload; just show upload commands")
     )
     (@subcommand prune =>
       (about: "prune branches that have been merged")
@@ -612,6 +615,7 @@ fn main() {
           submatches.is_present("BRANCH_NAME_AS_TOPIC"),
           autosubmit.unwrap_or(config.autosubmit),
           presubmit.unwrap_or(config.presubmit),
+          submatches.is_present("DRY_RUN"),
         )
       }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -883,6 +883,7 @@ impl Tree {
     branch_name_as_topic: bool,
     autosubmit: bool,
     presubmit_ready: bool,
+    dry_run: bool,
   ) -> Result<i32, Error> {
     // TODO: Use a pool for >1, figure out how 0 (all projects) should work.
     ensure!(
@@ -982,8 +983,12 @@ impl Tree {
           wip: wip,
         },
       );
-      let git_output = cmd.output().context("failed to spawn git push")?;
-      println!("{}", String::from_utf8_lossy(&git_output.stderr));
+      if dry_run {
+        println!("running: {:?}", cmd);
+      } else {
+        let git_output = cmd.output().context("failed to spawn git push")?;
+        println!("{}", String::from_utf8_lossy(&git_output.stderr));
+      }
     }
 
     Ok(0)

--- a/src/util.rs
+++ b/src/util.rs
@@ -106,7 +106,7 @@ pub struct UploadOptions<'a> {
 pub fn make_push_command(
   project_path: std::path::PathBuf,
   remote: &String,
-  dest_branch_name: &String,
+  dest_branch_name: &str,
   options: &UploadOptions,
 ) -> std::process::Command {
   // https://gerrit-review.googlesource.com/Documentation/user-upload.html#push_options


### PR DESCRIPTION
This handles multiple *explicitly named* projects. `--cbr` with no
paths is still TODO.