### PR TITLE
Switch to stable rust, fix build break.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: jmgao/ubuntu-cosmic-mingw-w64-rust:latest
+      - image: jmgao/ubuntu-cosmic-mingw-w64-rust:20190928
     steps:
       - checkout
       - run:
@@ -16,10 +16,7 @@ jobs:
           command: apt-get install libssl-dev
       - run:
           name: Build
-          command: cargo build
+          command: cargo +stable build
       - run:
           name: Test
-          command: cargo test
-      - run:
-          name: Clippy
-          command: cargo clippy
+          command: cargo +stable test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ lazy_static = "1.3.0"
 
 log = "0.4"
 failure = "0.1"
-futures-preview = "0.3.0-alpha.17"
+futures-preview = "0.3.0-alpha.19"
 indoc = "0.3"
 
 serde = "1.0"
 serde_derive = "1.0"
 toml = "0.5"
 quick-xml = "0.15.0"
-minidom = "0.11.0"
+minidom = "=0.11.0"
 
 clap = "2.32"
 maplit = "1.0"


### PR DESCRIPTION
 - Switch to rust stable, now that futures have been stabilized.
 - Explicitly choose minidom 0.11.0, because 0.11.1 seems to have
   broken compatibility with failure.