### PR TITLE
Manifest dumping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,10 @@ indoc = "0.3"
 serde = "1.0"
 serde_derive = "1.0"
 toml = "0.5"
-quick-xml = "0.15.0"
+
+# manifest::serialize::serializer passes a quick-xml value to minidom, so the quick-xml version
+# must match the version needed by minidom.
+quick-xml = "^0.14"
 minidom = "=0.11.0"
 
 clap = "2.32"

--- a/src/manifest/serializer.rs
+++ b/src/manifest/serializer.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use failure::{Error, ResultExt};
 
 use minidom::element::Element;
+use quick_xml::Writer;
 
 macro_rules! populate_from_option {
   ($elem: expr, $option: expr, $attribute_name: expr) => {{
@@ -72,6 +73,9 @@ pub fn serialize(manifest: &Manifest, mut output: Box<dyn Write>) -> Result<(), 
     root.append_child(elem.build());
   }
 
-  root.write_to(&mut output).context("failed to write manifest")?;
+  let mut fancy_writer = Writer::new_with_indent(&mut output, ' ' as u8, 4);
+  root.to_writer(&mut fancy_writer).context("failed to write manifest")?;
+  output.write(b"\n")?;
+
   Ok(())
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1555,7 +1555,7 @@ impl Tree {
       let mut manifest_project = manifest
         .projects
         .iter_mut()
-        .find(|(_k, v)| v.name == project_name)
+        .find(|(_k, v)| v.path.as_ref() == Some(&project_name))
         .ok_or_else(|| format_err!("failed to find project {} in manifest", project_name))?;
       manifest_project.1.revision = Some(format!("{}", project_status.commit));
     }


### PR DESCRIPTION
For the pretty-printing, the need for upgrading minidom and quick-xml in lockstep seems odd to me, but if the versions didn't exactly match, the build failed with this error:

```
expected struct `quick_xml::writer::Writer`, found a different struct `quick_xml::writer::Writer`
```

Even *with* the versions matching, my IDE's LSP/rls integration still shows this error. I guess it's not using the right crate versions somehow?
