### PR TITLE
Implement tag fetching.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,7 @@ fn cmd_clone(
     fetch_type,
     FetchTarget::Upstream,
     CheckoutType::Checkout,
+    false,
   )
 }
 
@@ -146,6 +147,7 @@ fn cmd_sync(
   fetch_type: FetchType,
   fetch_target: FetchTarget,
   checkout: CheckoutType,
+  fetch_tags: bool,
 ) -> Result<i32, Error> {
   tree.sync(
     &config,
@@ -154,6 +156,7 @@ fn cmd_sync(
     fetch_type,
     fetch_target,
     checkout,
+    fetch_tags,
   )
 }
 
@@ -252,11 +255,7 @@ fn cmd_preupload(
   tree.preupload(config, &mut pool, preupload_under)
 }
 
-fn cmd_find_deleted(
-  config: &Config,
-  mut pool: &mut Pool,
-  tree: &mut Tree,
-) -> Result<i32, Error> {
+fn cmd_find_deleted(config: &Config, mut pool: &mut Pool, tree: &mut Tree) -> Result<i32, Error> {
   tree.find_deleted(config, &mut pool)
 }
 
@@ -325,6 +324,7 @@ fn main() {
         (@arg BRANCH: -b --branch +takes_value +multiple number_of_values(1)
           "specify a branch to fetch (can be used multiple times)"
         )
+        (@arg FETCH_TAGS: -t --tags "fetch all remote tags")
       )
       (@arg PATH: ...
         "path(s) beneath which repositories are synced\n\
@@ -339,6 +339,7 @@ fn main() {
         "specify a branch to fetch (can be used multiple times)"
       )
       (@arg REFS_ONLY: -r --("refs-only") "don't checkout, only update the refs")
+      (@arg FETCH_TAGS: -t --tags "fetch all remote tags")
       (@arg PATH: ...
         "path(s) beneath which repositories are synced\n\
          defaults to all repositories in the tree if unspecified"
@@ -528,6 +529,7 @@ fn main() {
 
         let branches: Option<Vec<_>> = submatches.values_of("BRANCH").map(Iterator::collect);
         let fetch_all = submatches.is_present("FETCH_ALL");
+        let fetch_tags = submatches.is_present("FETCH_TAGS") || fetch_all;
 
         let fetch_target = {
           if fetch_all {
@@ -548,6 +550,7 @@ fn main() {
           FetchType::Fetch,
           fetch_target,
           CheckoutType::NoCheckout,
+          fetch_tags,
         )
       }
 
@@ -563,6 +566,7 @@ fn main() {
 
         let branches: Option<Vec<_>> = submatches.values_of("BRANCH").map(Iterator::collect);
         let fetch_all = submatches.is_present("FETCH_ALL");
+        let fetch_tags = submatches.is_present("FETCH_TAGS") || fetch_all;
 
         let fetch_target = {
           if fetch_all {
@@ -587,6 +591,7 @@ fn main() {
           } else {
             CheckoutType::Checkout
           },
+          fetch_tags,
         )
       }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -389,6 +389,7 @@ impl Tree {
         &remote_config,
         &remote_config.manifest,
         Some(&[branch.to_string()]),
+        false,
         None,
       )?;
     }
@@ -523,6 +524,7 @@ impl Tree {
     fetch_target: Option<FetchTarget>,
     checkout: CheckoutType,
     do_project_cleanup: bool,
+    fetch_tags: bool,
   ) -> Result<i32, Error> {
     let config = Arc::new(config.clone());
     let projects: Vec<Arc<_>> = projects.into_iter().map(Arc::new).collect();
@@ -550,7 +552,7 @@ impl Tree {
             FetchTarget::All => None,
           };
           depot
-            .fetch_repo(&remote, &project_info.project_name, target, None)
+            .fetch_repo(&remote, &project_info.project_name, target, fetch_tags, None)
             .context(format!("failed to fetch for project {}", project_info.project_name,))?;
 
           Ok(())
@@ -760,6 +762,7 @@ impl Tree {
     fetch_type: FetchType,
     fetch_target: FetchTarget,
     checkout: CheckoutType,
+    fetch_tags: bool,
   ) -> Result<i32, Error> {
     if fetch_type == FetchType::Fetch {
       // Sync the manifest repo first.
@@ -773,7 +776,15 @@ impl Tree {
 
       self.update_hooks()?;
 
-      self.sync_repos(&mut pool, config, manifest, Some(FetchTarget::Upstream), checkout, false)?;
+      self.sync_repos(
+        &mut pool,
+        config,
+        manifest,
+        Some(FetchTarget::Upstream),
+        checkout,
+        false,
+        fetch_tags,
+      )?;
     }
 
     let manifest = self.read_manifest()?;
@@ -789,6 +800,7 @@ impl Tree {
       },
       checkout,
       sync_under == None,
+      fetch_tags,
     )?;
     Ok(0)
   }


### PR DESCRIPTION
By default no tags are fetched. `pore fetch --tags` or `pore sync
--tags` will fetch remote tags.