### PR TITLE
Support non-default.xml manifests

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,20 @@ pub struct RemoteConfig {
   pub other_urls: Option<Vec<String>>,
   pub manifest: String,
   pub depot: String,
+
+  #[serde(default = "default_branch")]
+  pub default_branch: String,
+
+  #[serde(default = "default_manifest_file")]
+  pub default_manifest_file: String,
+}
+
+fn default_branch() -> String {
+  "master".into()
+}
+
+fn default_manifest_file() -> String {
+  "default.xml".into()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -70,6 +84,8 @@ impl Default for Config {
           other_urls: Some(vec!["persistent-https://android.googlesource.com/".into()]),
           manifest: "platform/manifest".into(),
           depot: "android".into(),
+          default_branch: default_branch(),
+          default_manifest_file: default_manifest_file(),
         },
       ],
       depots: btreemap! {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -369,6 +369,7 @@ impl Tree {
     path: T,
     remote_config: &RemoteConfig,
     branch: &str,
+    file: &str,
     group_filters: Vec<GroupFilter>,
     fetch: bool,
   ) -> Result<Tree, Error> {
@@ -381,8 +382,8 @@ impl Tree {
     std::fs::create_dir_all(&pore_path).context(format!("failed to create directory {:?}", pore_path))?;
 
     let manifest_path = pore_path.join("manifest");
-    create_symlink("manifest/default.xml", pore_path.join("manifest.xml"))
-      .context("failed to create manifest symlink")?;
+    let manifest_file = PathBuf::from("manifest").join(file);
+    create_symlink(manifest_file, pore_path.join("manifest.xml")).context("failed to create manifest symlink")?;
 
     if fetch {
       depot.fetch_repo(


### PR DESCRIPTION
Repo supports the `repo init ... -m <file>` option to switch away from the default "default.xml" and use a different manifest file.

Expand the target syntax for init/clone to support `remote/branch:file` -- like `aosp/master:aosp-master-with-phones.xml` so that this manifest works:

https://android.googlesource.com/platform/manifest/+/refs/heads/master/aosp-master-with-phones.xml

Also allows the configured remotes to override the global defaults of "master" and "default.xml".

Fixes #17