### PR TITLE
Parse and ignore <superproject> field.

### DIFF
--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -35,6 +35,7 @@ pub struct Manifest {
   pub projects: BTreeMap<PathBuf, Project>,
   pub default: Option<Default>,
   pub manifest_server: Option<ManifestServer>,
+  pub superproject: Option<SuperProject>,
   pub repo_hooks: Option<RepoHooks>,
 }
 
@@ -58,6 +59,12 @@ pub struct Default {
 #[derive(Debug)]
 pub struct ManifestServer {
   pub url: String,
+}
+
+#[derive(Debug)]
+pub struct SuperProject {
+  pub name: String,
+  pub remote: String,
 }
 
 #[derive(Default, Debug)]


### PR DESCRIPTION
https://android-review.googlesource.com/c/platform/manifest/+/1557212
says that clients that don't handle this field shouldn't have a
problem, and that it's experimental and not for general use yet.