### PR TITLE
Assorted improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ serde = "1.0"
 serde_derive = "1.0"
 toml = "0.5"
 
+regex = "1"
+serde_regex = "1"
+
 # manifest::serialize::serializer passes a quick-xml value to minidom, so the quick-xml version
 # must match the version needed by minidom.
 quick-xml = "^0.17"

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@ use super::depot::Depot;
 
 use failure::Error;
 use failure::ResultExt;
+use regex::Regex;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
@@ -44,6 +45,17 @@ fn default_presubmit() -> bool {
   false
 }
 
+fn default_project_renames() -> Vec<ProjectRename> {
+  Vec::new()
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProjectRename {
+  #[serde(with = "serde_regex")]
+  pub regex: Regex,
+  pub replacement: String,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RemoteConfig {
   pub name: String,
@@ -57,6 +69,9 @@ pub struct RemoteConfig {
 
   #[serde(default = "default_manifest_file")]
   pub default_manifest_file: String,
+
+  #[serde(default = "default_project_renames")]
+  pub project_renames: Vec<ProjectRename>,
 }
 
 fn default_branch() -> String {
@@ -85,6 +100,7 @@ impl Default for Config {
         depot: "android".into(),
         default_branch: default_branch(),
         default_manifest_file: default_manifest_file(),
+        project_renames: default_project_renames(),
       }],
       depots: btreemap! {
         "android".into() => DepotConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,7 +25,7 @@ use super::depot::Depot;
 use failure::Error;
 use failure::ResultExt;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
   #[serde(default = "default_autosubmit")]
   pub autosubmit: bool,
@@ -44,7 +44,7 @@ fn default_presubmit() -> bool {
   false
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RemoteConfig {
   pub name: String,
   pub url: String,
@@ -67,7 +67,7 @@ fn default_manifest_file() -> String {
   "default.xml".into()
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DepotConfig {
   pub path: String,
 }
@@ -108,10 +108,10 @@ impl Config {
     Ok(path.into_owned().into())
   }
 
-  pub fn find_remote(&self, remote_name: &str) -> Result<RemoteConfig, Error> {
+  pub fn find_remote(&self, remote_name: &str) -> Result<&RemoteConfig, Error> {
     for remote in &self.remotes {
       if remote.name == remote_name {
-        return Ok(remote.clone());
+        return Ok(remote);
       }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,7 @@ impl ProjectStatusDisplayData {
     };
 
     ProjectStatusDisplayData {
-      location: PROJECT_STYLE.apply_to(format!("project {}", status.name)).to_string(),
+      location: PROJECT_STYLE.apply_to(format!("project {}", status.path)).to_string(),
       branch: format!("{}{}", branch, ahead_behind),
       top_commit: status.commit_summary.clone().unwrap_or_default(),
       files: status

--- a/src/main.rs
+++ b/src/main.rs
@@ -399,8 +399,9 @@ fn cmd_forall(
   tree: &mut Tree,
   forall_under: Option<Vec<&str>>,
   command: &str,
+  repo_compat: bool,
 ) -> Result<i32, Error> {
-  tree.forall(config, &mut pool, forall_under, command)
+  tree.forall(config, &mut pool, forall_under, command, repo_compat)
 }
 
 fn cmd_preupload(
@@ -642,6 +643,7 @@ fn main() {
 
   set_trace_id();
 
+  let repo_compat = std::env::args().next() == Some("repo".into());
   let config_path = match matches.value_of("CONFIG") {
     Some(path) => {
       info!("using provided config path {:?}", path);
@@ -856,7 +858,14 @@ fn main() {
         let command = submatches
           .value_of("COMMAND")
           .ok_or_else(|| format_err!("no commands specified"))?;
-        cmd_forall(Arc::clone(&config), &mut pool, &mut tree, forall_under, command)
+        cmd_forall(
+          Arc::clone(&config),
+          &mut pool,
+          &mut tree,
+          forall_under,
+          command,
+          repo_compat,
+        )
       }
 
       ("preupload", Some(submatches)) => {

--- a/src/manifest/parser.rs
+++ b/src/manifest/parser.rs
@@ -334,7 +334,10 @@ fn parse_superproject(event: &BytesStart, reader: &Reader<impl BufRead>) -> Resu
 
   ensure!(name != None, "name not specified in <superproject>");
   ensure!(remote != None, "remote not specified in <superproject>");
-  Ok(SuperProject { name: name.unwrap(), remote: remote.unwrap() })
+  Ok(SuperProject {
+    name: name.unwrap(),
+    remote: remote.unwrap(),
+  })
 }
 
 fn parse_contactinfo(event: &BytesStart, reader: &Reader<impl BufRead>) -> Result<ContactInfo, Error> {
@@ -352,7 +355,9 @@ fn parse_contactinfo(event: &BytesStart, reader: &Reader<impl BufRead>) -> Resul
   }
 
   ensure!(bug_url != None, "bugurl not specified in <contactinfo>");
-  Ok(ContactInfo { bug_url: bug_url.unwrap() })
+  Ok(ContactInfo {
+    bug_url: bug_url.unwrap(),
+  })
 }
 
 fn parse_project(event: &BytesStart, reader: &mut Reader<impl BufRead>, has_children: bool) -> Result<Project, Error> {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -915,13 +915,7 @@ impl Tree {
     Ok(pool.execute(job))
   }
 
-  pub fn start(
-    &self,
-    config: &Config,
-    _depot: &Depot,
-    branch_name: &str,
-    directory: &Path,
-  ) -> Result<i32, Error> {
+  pub fn start(&self, config: &Config, _depot: &Depot, branch_name: &str, directory: &Path) -> Result<i32, Error> {
     let flags = git2::RepositoryOpenFlags::empty();
     let repo = git2::Repository::open_ext(&directory, flags, &self.path).context("failed to find git repository")?;
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -31,7 +31,7 @@ use walkdir::WalkDir;
 use crate::util::*;
 use crate::*;
 
-use config::RemoteConfig;
+use config::{ManifestConfig, RemoteConfig};
 use depot::Depot;
 use manifest::FileOperation;
 
@@ -373,6 +373,7 @@ impl Tree {
   pub fn construct<T: Into<PathBuf>>(
     depot: &Depot,
     path: T,
+    manifest_config: &ManifestConfig,
     remote_config: &RemoteConfig,
     branch: &str,
     file: &str,
@@ -391,21 +392,22 @@ impl Tree {
     let manifest_file = PathBuf::from("manifest").join(file);
     create_symlink(manifest_file, pore_path.join("manifest.xml")).context("failed to create manifest symlink")?;
 
+    let manifest_project = &manifest_config.project;
     if fetch {
       depot.fetch_repo(
         &remote_config,
-        &remote_config.manifest,
+        manifest_project,
         Some(&[branch.to_string()]),
         false,
         None,
       )?;
     }
-    depot.clone_repo(&remote_config, &remote_config.manifest, &branch, &manifest_path)?;
+    depot.clone_repo(&remote_config, manifest_project, &branch, &manifest_path)?;
 
     let tree_config = TreeConfig {
       remote: remote_config.name.clone(),
       branch: branch.into(),
-      manifest: remote_config.manifest.clone(),
+      manifest: manifest_config.remote.clone(),
       tags: Vec::new(),
       projects: Vec::new(),
       group_filters: Some(group_filters),

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1129,12 +1129,16 @@ impl Tree {
     for project in projects {
       let depot = Arc::clone(&depot);
       let tree_root = Arc::clone(&tree_root);
+      let config = Arc::clone(&config);
       job.add_task(project.project_path.clone(), move |_| -> Result<PruneResult, Error> {
         let path = tree_root.join(&project.project_path);
         let tree_repo =
           git2::Repository::open(&path).context(format!("failed to open repository {:?}", project.project_path))?;
 
-        let obj_repo_path = depot.objects_mirror(project.project_name);
+        let remote_config = config
+          .find_remote(&project.remote)
+          .context(format!("failed to find remote {}", project.remote))?;
+        let obj_repo_path = depot.objects_mirror(&remote_config, project.project_name);
         let obj_repo = git2::Repository::open_bare(&obj_repo_path)
           .context(format!("failed to open object repository {:?}", obj_repo_path))?;
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -210,6 +210,7 @@ pub struct FileStatus {
 #[derive(Debug)]
 pub struct ProjectStatus {
   pub name: String,
+  pub path: String,
   pub branch: Option<String>,
   pub commit: git2::Oid,
   pub commit_summary: Option<String>,
@@ -923,6 +924,7 @@ impl Tree {
 
         Ok(ProjectStatus {
           name: project.project_name.clone(),
+          path: project.project_path.clone(),
           branch,
           commit: commit.id(),
           commit_summary: commit.summary().map_or(None, |s| Some(s.to_string())),

--- a/src/util.rs
+++ b/src/util.rs
@@ -56,7 +56,6 @@ fn symlink<T: AsRef<Path> + Debug, U: AsRef<Path> + Debug>(target: T, symlink_pa
   }
 }
 
-
 /// Create a symlink, or if it already exists, check that it points to the right place.
 pub fn create_symlink<T: AsRef<Path> + Debug, U: AsRef<Path> + Debug>(target: T, symlink_path: U) -> Result<(), Error> {
   let target = target.as_ref();


### PR DESCRIPTION
Adds functionality that you guys aren't going to need to remap project names onto shared depots (e.g. `aosp/platform/bionic` -> `platform/bionic`), and separates configuration of remote and manifest.

cc @rprichard