### PR TITLE
Add link to GitHub repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Josh Gao <josh@jmgao.dev>"]
 edition = "2018"
 license = "Apache-2.0"
 description = "a performance oriented reimplementation of repo"
+repository = "https://github.com/jmgao/pore"
 
 [dependencies]
 lazy_static = "1.4.0"


### PR DESCRIPTION
Add link to GitHub repo in Cargo.toml. This makes discovering it from the crates.io listing easier.

Signed-off-by: Michel Alexandre Salim <salimma@fedoraproject.org>