### PR TITLE
Bump joinery dependency to 3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "joinery"
-version = "2.1.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
+checksum = "57d8bde02bbf44a562cf068a8ff4a68842df387e302a03a4de4a57fcf82ec377"
 
 [[package]]
 name = "js-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,4 @@ progpool = "0.2"
 tracing_facade = "0.1"
 tracing_chromium = "0.1"
 
-joinery = "2.1.0"
+joinery = "3.0"


### PR DESCRIPTION
This is a safe update since `pore` does not use `peek` or `peek_item`: https://github.com/Lucretiel/joinery/blob/master/CHANGELOG.md

Signed-off-by: Michel Alexandre Salim <salimma@fedoraproject.org>