### PR TITLE
Include 'name' attribute to project elem in the manifest XML

### DIFF
--- a/src/manifest/serializer.rs
+++ b/src/manifest/serializer.rs
@@ -52,6 +52,7 @@ pub fn serialize(manifest: &Manifest, mut output: Box<dyn Write>) -> Result<(), 
 
   for project in manifest.projects.values() {
     let mut elem = Element::builder("project");
+    populate_from_option!(elem, Some(&project.name), "name");
     populate_from_option!(elem, project.path, "path");
     populate_from_option!(elem, project.remote, "remote");
     populate_from_option!(elem, project.revision, "revision");


### PR DESCRIPTION
Without this, trying to pore sync using the generated manifest fails with: 'fatal: failed to read manifest: name not specified in <project>'