### PR TITLE
Compatibility for `repo start <branch> <path>`.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,10 @@ enum Commands {
     /// Point branch at this revision instead of upstream
     #[arg(short, long, visible_alias = "rev")]
     revision: Option<String>,
+
+    /// Path to the project to start a branch in. If omitted, the current
+    /// directory will be used.
+    path: Option<PathBuf>,
   },
 
   /// Rebase local branch onto upstream branch
@@ -1036,13 +1040,13 @@ fn main() {
           no_lfs,
         )
       }
-      Commands::Start { branch, revision } => {
+      Commands::Start { branch, revision, path } => {
         let tree = Tree::find_from_path(cwd.clone())?;
 
         let remote_config = config.find_remote(&tree.config.remote)?;
         let depot = config.find_depot(&remote_config.depot)?;
 
-        tree.start(Arc::clone(&config), &depot, branch, revision, &cwd)
+        tree.start(Arc::clone(&config), &depot, branch, revision, &path.unwrap_or(cwd))
       }
       Commands::Rebase {
         interactive,

--- a/src/repo_main_trampoline.py
+++ b/src/repo_main_trampoline.py
@@ -1,0 +1,34 @@
+"""A launcher that will be run by `repo`.
+
+There's a .repo/repo/repo tool that gets installed which runs pore in a repo-compatible
+mode, but unless run directly (which few tools that run repo do, they usually expect the
+thing in PATH to work), that won't be used. repo, when run from PATH rather the
+installed .repo/repo/repo, will check for a .repo/repo/main.py and run that. For a real
+repo tree, that's the full implementation of repo. We don't want that, we just want to
+intercept that call and redirect to pore.
+"""
+import argparse
+import subprocess
+from pathlib import Path
+
+THIS_DIR = Path(__file__).parent
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    # These arguments are passed to the real repo by the repo launched (the thing in
+    # PATH). We don't care about them, but we need to ignore them.
+    parser.add_argument("--repo-dir")
+    parser.add_argument("--wrapper-version")
+    parser.add_argument("--wrapper-path")
+    _, other_args = parser.parse_known_args()
+
+    # It also follows those arguments with -- before forwarding the user's arguments.
+    # clap doesn't like that, nor does it need it, so just drop it.
+    if other_args and other_args[0] == "--":
+        other_args = other_args[1:]
+    subprocess.run([str(THIS_DIR / "repo")] + other_args, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -997,6 +997,13 @@ impl Tree {
       "#!/bin/bash\nexec -a repo pore \"${@}\"\n",
     )?;
 
+    // Also write a main.py to the directory so that a bare `repo` can use it.
+    self.write_hook(
+      &repo_bin_dir.as_path(),
+      "main.py",
+      include_str!("repo_main_trampoline.py"),
+    )?;
+
     Ok(())
   }
 


### PR DESCRIPTION
The first commit expands the stub install of `.repo` with a `.repo/repo/main.py` so that `repo` run from `PATH` will find and run `.repo/repo/repo` rather than requiring tools to find and run that directly (I have yet to see any tool, not even repo itself, which does that).

The second adds the optional path argument to `pore start`, since repo accepts that, and pore can't otherwise handle input from tools written for repo.

See each commit message for more details.