### PR TITLE
Update git2 from v0.16 to v0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,11 +497,11 @@ checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "git2"
-version = "0.16.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
+checksum = "1b3ba52851e73b46a4c3df1d89343741112003f0f6f13beb0dfac9e457c3fdcd"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -744,9 +744,9 @@ checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.2+1.5.1"
+version = "0.16.2+1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",
@@ -769,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.23"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ walkdir = "2.3.2"
 fs2 = "0.4.3"
 filetime = "0.2.19"
 
-git2 = { version = "0.16", features = ["vendored-libgit2"] }
+git2 = { version = "0.18", features = ["vendored-libgit2"] }
 
 atty = "0.2"
 reqwest = { version = "0.11.9", features = ["blocking"] }


### PR DESCRIPTION
There were recent medium and high severity security vulnerabilities in libgit2. Only the v0.18 branch of the git2 crate has addressed this by updating the bundled libgit2 sources.

c.f. https://rustsec.org/advisories/RUSTSEC-2024-0013.html
c.f. https://github.com/advisories/GHSA-22q8-ghmq-63vf
c.f. https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-24575
c.f. https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-24577