### PR TITLE
Force manifest branch creation during `pore sync`

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -843,12 +843,7 @@ impl Tree {
                 .peel_to_commit()
                 .context("failed to peel HEAD to commit")?;
 
-              let mut branch = match repo.find_branch("default", git2::BranchType::Local) {
-                Ok(branch) => branch,
-                Err(_) => repo
-                  .branch("default", &head, true)
-                  .context("failed to create manifest default branch")?,
-              };
+              let mut branch = repo.branch("default", &head, true).context("failed to create manifest default branch")?;
 
               // TODO: repo uses origin as the upstream, regardless of what the remote is called.
               branch


### PR DESCRIPTION
The current flow is something like:
1. pull remote
2. checkout remote
3. if `default` local branch exists, then `set_upstream` and then checkout `default`

This reverts the manifest project back the local `default` branch _before_ pulling: ie
the `default` branch, if it previously existed, does not get updated to reflect the remote branch.

This seems incorrect and leaves the repo in a weird state until the dev manually intervenes, which also
doesn't always happen because this does not show up in `pore status`.

I'm not sure overwriting the local `default` branch is the right thing to do.

Some other options:
1. For `pore sync -d` why use the `default` branch at all vs a detached head?
2. If there are local changes, try to autorebase any local changes onto the remote branch and spit out a useful error message if that fails?