### PR TITLE
Add checkout subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,12 @@ enum Commands {
     local: bool,
   },
 
+  /// Checkout a branch for development
+  Checkout {
+    /// Specify a branch to checkout
+    branch: String,
+  },
+
   /// Checkout a new tree into a new directory
   Clone {
     /// The target to checkout in the format <REMOTE>[/<BRANCH>[:MANIFEST]]
@@ -392,6 +398,7 @@ impl std::fmt::Display for Commands {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
       Commands::Init { .. } => write!(f, "init"),
+      Commands::Checkout { .. } => write!(f, "checkout"),
       Commands::Clone { .. } => write!(f, "clone"),
       Commands::Fetch { .. } => write!(f, "fetch"),
       Commands::Sync { .. } => write!(f, "sync"),
@@ -975,6 +982,10 @@ fn main() {
           group_filters.as_deref(),
           fetch,
         )
+      }
+      Commands::Checkout { branch } => {
+        let tree = Tree::find_from_path(cwd)?;
+        tree.checkout(&config, &mut pool, &branch)
       }
       Commands::Clone {
         target,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1061,6 +1061,68 @@ impl Tree {
     Ok(())
   }
 
+  pub fn checkout(&self, config: &Config, pool: &mut Pool, target_branch: &str) -> Result<i32, Error> {
+    let projects = self.collect_manifest_projects(config, &self.read_manifest()?, None, None)?;
+
+    let mut job = Job::with_name("checkout");
+
+    for project in &projects {
+      let path = self.path.join(&project.project_path);
+      job.add_task(&project.project_path, move || -> Result<Option<&str>, Error> {
+        let repo =
+          git2::Repository::open(&path).with_context(|| format!("failed to open object repository {:?}", path))?;
+
+        let maybe_parse = match repo.revparse_ext(target_branch) {
+          Ok(result) => Ok(Some(result)),
+          Err(error) => {
+            if error.code() == git2::ErrorCode::NotFound {
+              Ok(None)
+            } else {
+              Err(error)
+            }
+          }
+        }?;
+
+        if let Some((object, reference)) = maybe_parse {
+          repo.checkout_tree(&object, None)?;
+
+          match reference {
+            Some(repo_ref) => repo.set_head(repo_ref.name().unwrap())?,
+            None => repo.set_head_detached(object.id())?,
+          }
+
+          Ok(Some(&project.project_path))
+        } else {
+          Ok(None)
+        }
+      });
+    }
+
+    let results = pool.execute(job);
+
+    if !results.failed.is_empty() {
+      for error in results.failed {
+        eprintln!("{}: {}", error.name, error.result);
+      }
+      return Ok(1);
+    }
+
+    let mut has_projects = false;
+    let checkout_projects = results.successful.into_iter().filter_map(|result| result.result);
+
+    for checkout_project in checkout_projects {
+      has_projects = true;
+      println!("Checked out {checkout_project}");
+    }
+
+    if has_projects {
+      Ok(0)
+    } else {
+      eprintln!("error: no project has branch {target_branch}");
+      Ok(1)
+    }
+  }
+
   pub fn sync(
     &mut self,
     config: &Config,


### PR DESCRIPTION
This [`command`] allows for the checking out of a topic branch across
multiple repos. When working on a change that effects multiple repos,
the general flow is to create a branch with the same name for ever repo
that the change touches. These changes are then sent to gerrit and
linked together under a topic. When landing, these changes are applied
to their respective repos atomically. This change adds the checkout
subcommand which allows the developer to change topic branches in their
repo checkout easily.

[`command`]: https://gerrit.googlesource.com/git-repo/+/refs/heads/main/subcmds/branches.py
