### PR TITLE
Add branches subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ extern crate anyhow;
 #[macro_use]
 extern crate serde_derive;
 
+use std::borrow::Cow;
 use std::cmp;
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto as _;
@@ -33,7 +34,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Error};
 use atty::Stream;
-use joinery::Joinable;
+use joinery::{Joinable, JoinableIterator};
 use progpool::{Job, Pool};
 
 #[macro_export]
@@ -123,6 +124,9 @@ enum Commands {
     #[arg(short)]
     local: bool,
   },
+
+  /// List the topic branches
+  Branches {},
 
   /// Checkout a new tree into a new directory
   Clone {
@@ -392,6 +396,7 @@ impl std::fmt::Display for Commands {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
       Commands::Init { .. } => write!(f, "init"),
+      Commands::Branches { .. } => write!(f, "branches"),
       Commands::Clone { .. } => write!(f, "clone"),
       Commands::Fetch { .. } => write!(f, "fetch"),
       Commands::Sync { .. } => write!(f, "sync"),
@@ -445,6 +450,46 @@ fn parse_group_filters(group_filters: &str) -> Vec<GroupFilter> {
     .collect();
 
   group_filters
+}
+
+fn cmd_branches(config: Config, pool: &mut Pool, tree: &Tree) -> Result<i32, Error> {
+  let results = tree.branches(config, pool)?;
+
+  if results.failed.is_empty() {
+    let projects_with_topic_branch = results.successful.into_iter().filter_map(|execution_result| {
+      if !execution_result.result.branches.is_empty() {
+        Some(execution_result.result)
+      } else {
+        None
+      }
+    });
+
+    for project in projects_with_topic_branch {
+      println!(
+        "{}: {}",
+        project.name,
+        project
+          .branches
+          .iter()
+          .map(|branch| {
+            if branch.is_head {
+              Cow::Owned(format!("*{}", branch.name))
+            } else {
+              Cow::Borrowed(&branch.name)
+            }
+          })
+          .join_with(", ")
+      );
+    }
+
+    Ok(0)
+  } else {
+    for error in results.failed {
+      eprintln!("{}: {}", error.name, error.result);
+    }
+
+    Ok(1)
+  }
 }
 
 fn cmd_clone(
@@ -975,6 +1020,10 @@ fn main() {
           group_filters.as_deref(),
           fetch,
         )
+      }
+      Commands::Branches {} => {
+        let tree = Tree::find_from_path(cwd)?;
+        cmd_branches(config, &mut pool, &tree)
       }
       Commands::Clone {
         target,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -319,6 +319,18 @@ pub struct ProjectStatus {
   pub behind: usize,
 }
 
+#[derive(Debug)]
+pub struct ProjectBranchStatus {
+  pub name: String,
+  pub branches: Vec<BranchStatus>,
+}
+
+#[derive(Debug)]
+pub struct BranchStatus {
+  pub name: String,
+  pub is_head: bool,
+}
+
 pub struct BranchInfo<'repo> {
   pub name: String,
   pub commit: git2::Commit<'repo>,
@@ -1161,6 +1173,47 @@ impl Tree {
     }
 
     Ok(0)
+  }
+
+  pub fn branches(
+    &self,
+    config: Config,
+    pool: &mut Pool,
+  ) -> Result<ExecutionResults<ProjectBranchStatus, Error>, Error> {
+    let projects = self.collect_manifest_projects(&config, &self.read_manifest()?, None, None)?;
+
+    let mut job = Job::with_name("branches");
+
+    for project in projects {
+      job.add_task(
+        project.project_path.clone(),
+        move || -> Result<ProjectBranchStatus, Error> {
+          let repo = git2::Repository::open(self.path.join(&project.project_path))
+            .with_context(|| format!("failed to open object repository {:?}", project.project_path))?;
+
+          let topic_branch_results = repo.branches(Some(git2::BranchType::Local))?;
+          let mut branches = Vec::new();
+
+          for topic_branch_result in topic_branch_results {
+            let (topic_branch, _) = topic_branch_result?;
+            branches.push(BranchStatus {
+              name: topic_branch
+                .name()?
+                .expect("Branch should have utf-8 encoded name")
+                .to_owned(),
+              is_head: topic_branch.is_head(),
+            });
+          }
+
+          Ok(ProjectBranchStatus {
+            name: project.project_name,
+            branches,
+          })
+        },
+      );
+    }
+
+    Ok(pool.execute(job))
   }
 
   pub fn status(


### PR DESCRIPTION
Added the [`branches`] subcommand which will print out all projects that
have a topic branch in their repo. This makes it very easy to find
which repos have what topic branches and pairs with the checkout
subcommand which allows developers to easily switch between their
cross repo changes and check on the status of these changes.

[`branches`]: https://android.googlesource.com/tools/repo/+/refs/heads/main/subcmds/branches.py
